### PR TITLE
Multi-shader example.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'glfw3'
-gem 'opengl-core'
+gem 'opengl-core', :git => 'https://github.com/jgleesawn/opengl-core' #:path => '~/gems/opengl-core/'
 gem 'opengl-aux'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/jgleesawn/opengl-core
+  revision: 760ffe831a53bee2ddd8b2ec112b15ee76f3fe9e
+  specs:
+    opengl-core (2.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -5,13 +11,13 @@ GEM
     opengl-aux (1.0.0.pre3)
       opengl-core (~> 2.0)
       snow-data (~> 1.3, >= 1.3.1)
-    opengl-core (2.0.1)
     snow-data (1.3.1)
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   glfw3
   opengl-aux
-  opengl-core
+  opengl-core!

--- a/core/game.rb
+++ b/core/game.rb
@@ -27,11 +27,19 @@ module Core
     end
 
     def push_point game_object
-      @graphics.add_object :ptb, game_object.get_gl_data
+      @graphics.add_object :ftb, game_object.get_gl_data
     end
 
     def pop_point
-      @graphics.remove_object :ptb
+      @graphics.remove_object :ftb
+    end
+
+    def push_vso game_object
+      @graphics.add_object :vstb, game_object.get_gl_data
+    end
+
+    def pop_vso
+      @graphics.remove_object :vstb
     end
   end
 

--- a/core/game.rb
+++ b/core/game.rb
@@ -5,7 +5,6 @@ module Core
     end
 
     def start &update_block
-      @graphics.buffer
       until quit_game?
         @graphics.wait_events
         @graphics.clear_buffer
@@ -20,11 +19,19 @@ module Core
     end
 
     def push_go game_object
-      @graphics.add_point game_object.get_gl_data
+      @graphics.add_object :otb, game_object.get_gl_data
     end
 
     def pop_go
-      @graphics.remove_point
+      @graphics.remove_object :otb
+    end
+
+    def push_point game_object
+      @graphics.add_object :ptb, game_object.get_gl_data
+    end
+
+    def pop_point
+      @graphics.remove_object :ptb
     end
   end
 

--- a/core/graphics.rb
+++ b/core/graphics.rb
@@ -100,7 +100,11 @@ module Core
 
     def error_check
       error = GL::glGetError()
-      raise "GLError: #{error.to_s(16)}" unless error == GL::GL_NO_ERROR
+      if error != GL::GL_NO_ERROR
+        puts "GLError: #{error.to_s(16)}" 
+        puts caller
+      end
+#      raise "GLError: #{error.to_s(16)}" unless error == GL::GL_NO_ERROR
     end
 
     def configure_gl_version version='3.2'

--- a/core/graphics.rb
+++ b/core/graphics.rb
@@ -95,11 +95,12 @@ module Core
       @objecttypes[:otb] = ObjectTypeBuffer.new(program)
       Core::error_check
 
-      vertex_shader = compile_shader GL::GL_VERTEX_SHADER, "core/shaders/point.vert"
+      vertex_shader = compile_shader GL::GL_VERTEX_SHADER, "core/shaders/geometry.vert"
+      geometry_shader = compile_shader GL::GL_GEOMETRY_SHADER, "core/shaders/filled.geom"
       fragment_shader = compile_shader GL::GL_FRAGMENT_SHADER, "core/shaders/passthru.frag"
       Core::error_check
 
-      program = create_shader_program vertex_shader, fragment_shader
+      program = create_shader_program vertex_shader, geometry_shader, fragment_shader
       @objecttypes[:ptb] = ObjectTypeBuffer.new(program)
       Core::error_check
     end

--- a/core/shaders/filled.geom
+++ b/core/shaders/filled.geom
@@ -1,16 +1,13 @@
 #version 330 core
 
 layout(points) in;
-layout(line_strip, max_vertices = 4) out;
+layout(triangle_strip, max_vertices = 3) out;
 
 void main() {
-    gl_Position = gl_in[0].gl_Position + vec4(-0.1, 0.0, 0.0, 0.0);
+    gl_Position = gl_in[0].gl_Position + vec4(0.0, 0.1, 0.0, 0.0);
     EmitVertex();
 
     gl_Position = gl_in[0].gl_Position + vec4(0.1, 0.0, 0.0, 0.0);
-    EmitVertex();
-
-    gl_Position = gl_in[0].gl_Position + vec4(0.0, 0.1, 0.0, 0.0);
     EmitVertex();
 
     gl_Position = gl_in[0].gl_Position + vec4(-0.1, 0.0, 0.0, 0.0);

--- a/core/shaders/geometry.geom
+++ b/core/shaders/geometry.geom
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 layout(points) in;
 layout(line_strip, max_vertices = 2) out;

--- a/core/shaders/geometry.vert
+++ b/core/shaders/geometry.vert
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 layout( location = 0 ) in vec2 pos;
 // in vec3 color;

--- a/core/shaders/passthru.frag
+++ b/core/shaders/passthru.frag
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 out vec4 fColor;
 

--- a/core/shaders/passthru.vert
+++ b/core/shaders/passthru.vert
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 layout( location = 0 ) in vec4 vPosition;
 

--- a/core/shaders/point.vert
+++ b/core/shaders/point.vert
@@ -1,0 +1,14 @@
+#version 330 core
+
+layout( location = 0 ) in vec2 pos;
+// in vec3 color;
+// in float sides;
+
+// out vec3 vColor;
+// out float vSides;
+
+void main() {
+    gl_Position = vec4(pos, 0.0, 1.0);
+//   vColor = vec3( 0.0, 0.0, 1.0 );
+//    vSides = sides;
+}

--- a/core/shaders/vside.geom
+++ b/core/shaders/vside.geom
@@ -3,15 +3,12 @@
 layout(points) in;
 layout(line_strip, max_vertices = 50) out;
 
-in VS_OUT {
-  float vsides;
-} gs_in[];  
-//in float vsides[];
+in float vsides[];
 
 const float PI = 3.1415926;
 
 void main() {
-    float fd = gs_in[0].vsides;
+    float fd = vsides[0];
     for (float f=0.0; f<fd; f+=1.0 ) {
       float ang = f * PI * 2.0 / fd;
 

--- a/core/shaders/vside.geom
+++ b/core/shaders/vside.geom
@@ -1,0 +1,37 @@
+#version 330 core
+
+layout(points) in;
+layout(line_strip, max_vertices = 50) out;
+
+in VS_OUT {
+  float vsides;
+} gs_in[];  
+//in float vsides[];
+
+const float PI = 3.1415926;
+
+void main() {
+    float fd = gs_in[0].vsides;
+    for (float f=0.0; f<fd; f+=1.0 ) {
+      float ang = f * PI * 2.0 / fd;
+
+      vec4 offset = vec4(cos(ang) * 0.075, -sin(ang) * 0.1, 0.0, 0.0);
+      gl_Position = gl_in[0].gl_Position + offset;
+
+      EmitVertex();
+    }
+    vec4 offset = vec4( 0.075, 0.0, 0.0, 0.0 );
+    gl_Position = gl_in[0].gl_Position + offset;
+    EmitVertex();
+/*
+    gl_Position = gl_in[0].gl_Position + vec4(0.0, 0.1, 0.0, 0.0);
+    EmitVertex();
+
+    gl_Position = gl_in[0].gl_Position + vec4(0.1, 0.0, 0.0, 0.0);
+    EmitVertex();
+
+    gl_Position = gl_in[0].gl_Position + vec4(-0.1, 0.0, 0.0, 0.0);
+    EmitVertex();
+*/
+    EndPrimitive();
+}

--- a/core/shaders/vside.vert
+++ b/core/shaders/vside.vert
@@ -1,0 +1,17 @@
+#version 330 core
+
+layout( location = 0 ) in vec2 pos;
+// in vec3 color;
+layout( location = 1 ) in float sides;
+
+// out vec3 vColor;
+out VS_OUT {
+  float vsides;
+} vs_out;  
+//out float vsides;
+
+void main() {
+    gl_Position = vec4(pos, 0.0, 1.0);
+//   vColor = vec3( 0.0, 0.0, 1.0 );
+    vs_out.vsides = sides;
+}

--- a/core/shaders/vside.vert
+++ b/core/shaders/vside.vert
@@ -5,13 +5,10 @@ layout( location = 0 ) in vec2 pos;
 layout( location = 1 ) in float sides;
 
 // out vec3 vColor;
-out VS_OUT {
-  float vsides;
-} vs_out;  
-//out float vsides;
+out float vsides;
 
 void main() {
     gl_Position = vec4(pos, 0.0, 1.0);
 //   vColor = vec3( 0.0, 0.0, 1.0 );
-    vs_out.vsides = sides;
+    vsides = sides;
 }

--- a/game.rb
+++ b/game.rb
@@ -14,5 +14,7 @@ game = Core::Game.new
 
 game.start do
   300.times { game.pop_go }
+  200.times { game.pop_point }
   300.times { game.push_go RandomPoint.new }
+  200.times { game.push_point RandomPoint.new }
 end

--- a/game.rb
+++ b/game.rb
@@ -10,11 +10,21 @@ class RandomPoint < Core::GameObject
   end
 end
 
+class RandomPointSides < Core::GameObject
+  @shader = :vside
+
+  def get_gl_data
+    [rand * 2 - 1, rand * 2 - 1, 1 + rand * 20]
+  end
+end  
+
 game = Core::Game.new
 
 game.start do
-  300.times { game.pop_go }
-  200.times { game.pop_point }
-  300.times { game.push_go RandomPoint.new }
-  200.times { game.push_point RandomPoint.new }
+#  100.times { game.pop_go }
+#  100.times { game.pop_point }
+  100.times { game.pop_vso }
+#  100.times { game.push_go RandomPoint.new }
+#  100.times { game.push_point RandomPoint.new }
+  100.times { game.push_vso RandomPointSides.new }
 end

--- a/game.rb
+++ b/game.rb
@@ -1,3 +1,5 @@
+require 'bundler/setup'
+Bundler.require(:default)
 require_relative 'core/core'
 
 class RandomPoint < Core::GameObject


### PR DESCRIPTION
The shaders are almost identical, but you can catch the drift.  It can be expanded to other data types that are passed into the vertex shader by having a different class type.  The initialize/buffer/add_object functions need to be customized to match the data structure you want to pass into the vertex shader.
--Written about the Rework commit.

If you apply and look at the commits:
  -Rework into a multi-shader program example.
  -Shows difference between two different geometry shaders a little clearer.
  -Uses geometric shader with a variable number of sides input.
One at a time, you can probably follow the changes a little easier than if you just look at the last one.  
The last commit was just showing a change in variable type passing from a fragment shader to a geometry shader.
The first commit was solely changes needed so it would work on the Windows box.  You may have to ignore it, or at least change the Gemfile back, I think jgleesawn/opengl-core doesn't run on a Mac.
